### PR TITLE
Added type declarations

### DIFF
--- a/tests/data/InDifferentClassRepository.php
+++ b/tests/data/InDifferentClassRepository.php
@@ -9,6 +9,9 @@ class InDifferentClassRepository
         return $pdo->query("SELECT * FROM users");
     }
 
+    /**
+     * @return iterable<object{userid: int<0, 4294967295>, email: string}&stdClass>
+     */
     public function queryColumnList(\PDO $pdo): \PDOStatement
     {
         return $pdo->query("SELECT userid, email FROM users");

--- a/tests/data/MethodsInSameClass.php
+++ b/tests/data/MethodsInSameClass.php
@@ -6,6 +6,9 @@ use function PHPStan\Testing\assertType;
 
 class MethodsInSameClass
 {
+    /**
+     * @return iterable<object{userid: int<0, 4294967295>, email: string, password_hash: string}&stdClass>
+     */
     protected function query(\PDO $pdo): \PDOStatement
     {
         return $pdo->query("SELECT * FROM users");

--- a/tests/data/phpdoc-only.php
+++ b/tests/data/phpdoc-only.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @var \PDOStatement $results
+ * @var iterable<stdClass> $results
  */
 
 use function PHPStan\Testing\assertType;


### PR DESCRIPTION
I have added the necessary type declarations. it should work like that, but I did not verify.

phpstan-dba - like PHPStan core itself - cannot do analysis across method boundaries.
therefore you always have to define return/parameter types to make it work in case you spread your code across several methods

you may ignore errors about invalid return types for the methods involved.

---

I have spent my freetime while looking into the issue at hand. please consider supporting my open source work by sponsoring my efforts ;)

https://github.com/sponsors/staabm